### PR TITLE
Fix tests in ruby 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: ruby
 dist: trusty
 cache: bundler
 script: bundle exec rspec
+rvm:
+  - 2.3.1
+  - 2.4.4
+  - 2.5.1

--- a/lib/travis/logger/format.rb
+++ b/lib/travis/logger/format.rb
@@ -1,3 +1,5 @@
+require 'time'
+
 module Travis
   class Logger
     class Format


### PR DESCRIPTION
I needed this small change for tests to pass in my local Ruby 2.5. The `iso8601` method is defined in `time.rb` (not `time.c` like most of the `Time` class), but depending on the Ruby version and other things it is probably already loaded (so this is almost certainly not an issue in any real application).

I also updated `.travis.yml` to build in more recent rubies (to check my fix).