### PR TITLE
Refactor + Support hashes and other objects as messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: ruby
 dist: trusty
 cache: bundler
 script: bundle exec rspec
+rvm:
+  - 2.3.1
+  - 2.4.4
+  - 2.5.1

--- a/lib/travis/logger.rb
+++ b/lib/travis/logger.rb
@@ -23,15 +23,6 @@ module Travis
 
     [:fatal, :error, :warn, :info, :debug].each do |level|
       define_method(level) do |msg, options = {}|
-        if msg.is_a?(Exception)
-          exception = msg
-          msg = "#{exception.class.name}: #{exception.message}"
-          msg << "\n#{exception.backtrace.join("\n")}" if exception.backtrace
-        end
-
-        msg = msg.join("\n") if msg.respond_to?(:join)
-        msg = msg.chomp + "\n"
-
         options.dup.tap do |opts|
           opts.delete(:progname)
 

--- a/lib/travis/logger.rb
+++ b/lib/travis/logger.rb
@@ -23,6 +23,7 @@ module Travis
 
     [:fatal, :error, :warn, :info, :debug].each do |level|
       define_method(level) do |msg, options = {}|
+        msg = msg.dup
         options.dup.tap do |opts|
           opts.delete(:progname)
 

--- a/lib/travis/logger/format.rb
+++ b/lib/travis/logger/format.rb
@@ -10,19 +10,27 @@ module Travis
       def call(severity, time, progname, message)
         l2met_args = message.respond_to?(:l2met_args) ? message.l2met_args : {}
 
-        if message.is_a?(Exception)
+        send(
+          "format_#{config[:format_type] || 'traditional'}",
+          severity, time, progname, message_to_string(message), l2met_args
+        )
+      end
+
+      def message_to_string(message)
+        message = message.join("\n") if message.respond_to?(:join)
+
+        case message
+        when Exception
           exception = message
           message = "#{exception.class.name}: #{exception.message}"
           message << "\n#{exception.backtrace.join("\n")}" if exception.backtrace
+        when Hash
+          message = message.map do |k, v|
+            "#{k}=#{v.to_s}"
+          end.join(' ')
         end
 
-        message = message.join("\n") if message.respond_to?(:join)
         message = message.chomp + "\n"
-
-        send(
-          "format_#{config[:format_type] || 'traditional'}",
-          severity, time, progname, message, l2met_args
-        )
       end
 
       private

--- a/lib/travis/logger/format.rb
+++ b/lib/travis/logger/format.rb
@@ -8,7 +8,7 @@ module Travis
       end
 
       def call(severity, time, progname, message)
-        l2met_args = message.l2met_args
+        l2met_args = message.respond_to?(:l2met_args) ? message.l2met_args : {}
 
         if message.is_a?(Exception)
           exception = message

--- a/lib/travis/logger/format.rb
+++ b/lib/travis/logger/format.rb
@@ -1,3 +1,5 @@
+require 'time'
+
 module Travis
   class Logger
     class Format

--- a/lib/travis/logger/format.rb
+++ b/lib/travis/logger/format.rb
@@ -19,18 +19,23 @@ module Travis
       def message_to_string(message)
         message = message.join("\n") if message.respond_to?(:join)
 
-        case message
+        message = case message
         when Exception
           exception = message
-          message = "#{exception.class.name}: #{exception.message}"
-          message << "\n#{exception.backtrace.join("\n")}" if exception.backtrace
+          "#{exception.class.name}: #{exception.message}".tap do |s|
+            s << "\n#{exception.backtrace.join("\n")}" if exception.backtrace
+          end
         when Hash
-          message = message.map do |k, v|
+          message.map do |k, v|
             "#{k}=#{v.to_s}"
           end.join(' ')
+        when String
+          message.chomp
+        else
+          message.inspect
         end
 
-        message = message.chomp + "\n"
+        message + "\n"
       end
 
       private

--- a/spec/logger/format_spec.rb
+++ b/spec/logger/format_spec.rb
@@ -84,6 +84,12 @@ describe Travis::Logger::Format do
       expect(log).to eq("I banana\napple\norange\n")
     end
 
+    it 'logs a hash' do
+      logger.info(attr1: 'value1', attr2: 2)
+
+      expect(log).to eq("I attr1=value1 attr2=2\n")
+    end
+
     it 'formatter works with message without l2met_args' do
       now = Time.now
 

--- a/spec/logger/format_spec.rb
+++ b/spec/logger/format_spec.rb
@@ -96,6 +96,12 @@ describe Travis::Logger::Format do
       expect(log).to match(/\AI #<Object.+>\n\z/)
     end
 
+    it 'logs frozen objects' do
+      logger.info('hi'.freeze)
+
+      expect(log).to eq("I hi\n")
+    end
+
     it 'formatter works with message without l2met_args' do
       now = Time.now
 

--- a/spec/logger/format_spec.rb
+++ b/spec/logger/format_spec.rb
@@ -64,6 +64,12 @@ describe Travis::Logger::Format do
       logger.info('message')
       expect(log).to_not include('app[hub.1]: ')
     end
+
+    it 'formatter works with message without l2met_args' do
+      now = Time.now
+
+      expect(formatter.call('DEBUG', now, 'program', 'completely normal message')).to include('completely normal message')
+    end
   end
 
   context 'when using l2met format' do

--- a/spec/logger/format_spec.rb
+++ b/spec/logger/format_spec.rb
@@ -90,6 +90,12 @@ describe Travis::Logger::Format do
       expect(log).to eq("I attr1=value1 attr2=2\n")
     end
 
+    it 'logs any object' do
+      logger.info(Object.new)
+
+      expect(log).to match(/\AI #<Object.+>\n\z/)
+    end
+
     it 'formatter works with message without l2met_args' do
       now = Time.now
 

--- a/spec/logger/format_spec.rb
+++ b/spec/logger/format_spec.rb
@@ -65,6 +65,25 @@ describe Travis::Logger::Format do
       expect(log).to_not include('app[hub.1]: ')
     end
 
+    it 'logs a string' do
+      logger.info('hi')
+
+      expect(log).to eq("I hi\n")
+    end
+
+    it 'logs a exception' do
+      exception = StandardError.new('kaputt!').tap { |e| e.set_backtrace(['line 1', 'line 2']) }
+      logger.info(exception)
+
+      expect(log).to eq("I StandardError: kaputt!\nline 1\nline 2\n")
+    end
+
+    it 'logs an array' do
+      logger.info(%w{banana apple orange})
+
+      expect(log).to eq("I banana\napple\norange\n")
+    end
+
     it 'formatter works with message without l2met_args' do
       now = Time.now
 


### PR DESCRIPTION
The issue: `Travis::Logger` subclasses Ruby's `Logger` but breaks its contract:

* `Logger` doesn't care about the message object class, it just passes it to the formatter
* The default Ruby formatter doesn't have any restrictions on the message object (it has a [fallback case where it calls `inspect`](https://github.com/ruby/ruby/blob/trunk/lib/logger.rb#L607-L617))

`Travis::Logger` on the other hand assumes the message is either a `String`, an `Array`, or an `Exception`&sup1;, and it does it even [before calling the formatter](https://github.com/travis-ci/travis-logger/blob/master/lib/travis/logger.rb#L33). Some third party libraries (the case I found, [Grape](https://github.com/ruby-grape/grape)) make use of the aforementioned contract and pass something else (in the case of Grape, a `Hash`), causing an exception if a `Travis::Logger` instead of a `::Logger` is provided to them. Grape does this because it also provides some formatters that do fancy things with those hashes, which might be questionable, but in any case is allowed by the `::Logger` original contract.

&sup1; more accurately, an `Exception`, something that responds to `join` (usually an `Array`), or something that responds to `chomp` (usually an `String`). When you pass anything else, `chomp` gets called on it, raising a `NoMethodError` exception.

This PR:

* Refactors by moving the formatting code from `Travis::Logger` to `Travis::Format` so that the logger doesn't care about the message type
* Adds specific support for hashes and generic for everything else (`inspect`) in `Travis::Format`
* Adds some test cases for the old and new behavior

This changes keep the current behavior (does the same formatting when passed the things it is supposed to get passed), but adds compatibility with other libraries that might be passing something else, and _good-citizenship_ by decoupling `Travis::Logger` and `Travis::Format` (you could now use `Travis::Logger` with a different formatter including the Ruby default, or `Travis::Format` with a regular ruby `::Logger`).

**Notes:**

* This PR builds on top of #2, I needed that to run the tests in local
* Feel free to squash all together, I did separate commits for easier review